### PR TITLE
Fix incorrect destination for copied project directories

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,8 +57,9 @@ jobs:
       
       - name: Run and test that the image works
         run: |
-          docker run --name buoy -d buoy:test
-          docker exec --tty buoy flask --version
+          docker run --name buoy -p 5000:5000 -d buoy:test
+          for i in {1..3}; do curl -I http://localhost:5000 >/dev/null 2>&1 && break || sleep 2; done
+          curl -I http://localhost:5000 2>&1 | grep "HTTP/1.1 200"          
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ RUN --mount=type=bind,source=requirements/app.txt,target=/requirements.txt \
  && pip install ${PIP_OPTS} -r /requirements.txt
 
 # Copy project files
-COPY app.py templates/ static/ /buoy/
+COPY templates/ templates/
+COPY static/ static/
+COPY app.py app.py


### PR DESCRIPTION
This problem was introduced by and was not caught in CI. This PR also adds a basic HTTP check to the CI/CD workflow to help ensure the site is working before merging.